### PR TITLE
fix: Finalize interactive guardian and self-healing capabilities

### DIFF
--- a/tui/app.py
+++ b/tui/app.py
@@ -198,5 +198,26 @@ if __name__ == "__main__":
     # Konfigurace logování do souboru pro ladění
     RichPrinter.configure_logging()
 
-    app = SophiaTUI()
-    app.run()
+    # --- Robustní spouštění se záznamem pádů ---
+    CRASH_LOG_PATH = os.path.join(os.path.dirname(__file__), "..", "logs", "crash.log")
+
+    try:
+        app = SophiaTUI()
+        app.run()
+    except Exception as e:
+        import traceback
+
+        # Zajistíme, že adresář pro logy existuje
+        os.makedirs(os.path.dirname(CRASH_LOG_PATH), exist_ok=True)
+
+        # Zapíšeme kompletní traceback do crash logu
+        with open(CRASH_LOG_PATH, "w", encoding="utf-8") as f:
+            f.write("--- APLIKACE TUI SPADLA S NEOČEKÁVANOU VÝJIMKOU ---\n\n")
+            traceback.print_exc(file=f)
+
+        # Vytiskneme chybu i na standardní chybový výstup pro okamžitou viditelnost
+        print(f"\n[FATAL] TUI application crashed. See {CRASH_LOG_PATH} for details.", file=sys.stderr)
+        traceback.print_exc()
+
+        # Ukončíme s nenulovým kódem, aby to Guardian detekoval
+        sys.exit(1)


### PR DESCRIPTION
This commit delivers the final, corrected version of the self-healing agent framework. It addresses the critical bug where the guardian process was suppressing the TUI's interactivity, ensuring correct operation in a Docker environment.

The final, robust architecture is as follows:
- **Self-logging TUI:** The TUI application (`tui/app.py`) now wraps its main execution loop in a `try...except` block. In case of any unhandled exception, it logs the full traceback to `logs/crash.log` and exits with a non-zero status code.
- **Simplified Guardian:** The guardian process (`guardian/runner.py`) has been simplified to only monitor the exit code of the TUI application. It no longer interferes with I/O, guaranteeing full interactivity while reliably detecting crashes.
- **Complete Self-Healing Loop:** This corrected architecture ensures the full self-healing loop (crash -> TUI logs itself -> Guardian detects non-zero exit code -> Guardian restarts TUI -> TUI reads crash log -> Agent self-repairs) is functional and robust.