### PR TITLE
Refactor the TUI display system to decouple tool logic from presentat…

### DIFF
--- a/mcp_servers/tui_tools_server.py
+++ b/mcp_servers/tui_tools_server.py
@@ -10,56 +10,51 @@ project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
 if project_root not in sys.path:
     sys.path.insert(0, project_root)
 
-from core.rich_printer import RichPrinter
+# RichPrinter se zde již nepoužívá, volání se přesouvá do orchestratoru
 
 def inform_user(message: str) -> str:
     """
-    Zobrazí uživateli informativní zprávu se zeleným označením.
-    Použij pro běžná sdělení, potvrzení akcí nebo pozitivní výsledky.
+    Pošle informativní zprávu do TUI.
+    Vrací JSON pro zpracování v orchestratoru.
     """
-    RichPrinter.inform(message)
-    return message
+    return json.dumps({"display": "inform", "content": message})
 
 def warn_user(message: str) -> str:
     """
-    Zobrazí uživateli varování s oranžovým označením.
-    Použij pro upozornění na méně závažné problémy, které nevyžadují okamžitý zásah.
+    Pošle varovnou zprávu do TUI.
+    Vrací JSON pro zpracování v orchestratoru.
     """
-    RichPrinter.warning(message)
-    return message
+    return json.dumps({"display": "warning", "content": message})
 
 def error_user(message: str) -> str:
     """
-    Zobrazí uživateli chybovou hlášku s červeným označením.
-    Použij pro informování o závažných chybách, selhání operací nebo problémech.
+    Pošle chybovou zprávu do TUI.
+    Vrací JSON pro zpracování v orchestratoru.
     """
-    RichPrinter.error(message)
-    return message
+    return json.dumps({"display": "error", "content": message})
 
 def ask_user(question: str) -> str:
     """
-    Položí uživateli otázku a počká na jeho odpověď.
-    Tento nástroj by se měl používat střídmě, pouze když je interakce nezbytná.
-    Systém automaticky zpracuje odpověď, nemusíš na ni čekat.
+    Položí otázku v TUI.
+    Vrací JSON pro zpracování v orchestratoru.
     """
-    RichPrinter.ask(question)
-    return f"Byla položena otázka: {question}"
+    return json.dumps({"display": "ask", "content": question})
 
 def display_code(code: str, language: str = "python") -> str:
     """
-    Zobrazí uživateli formátovaný blok kódu se zvýrazněním syntaxe.
+    Pošle blok kódu pro zobrazení v TUI.
+    Vrací JSON pro zpracování v orchestratoru.
     """
-    RichPrinter.code(code, language)
-    return f"Zobrazen kód (jazyk: {language}):\n---\n{code}\n---"
+    content = {"code": code, "language": language}
+    return json.dumps({"display": "code", "content": content})
 
 def display_table(title: str, headers: list[str], rows: list[list[str]]) -> str:
     """
-    Zobrazí uživateli přehlednou tabulku s daty.
+    Pošle data pro zobrazení tabulky v TUI.
+    Vrací JSON pro zpracování v orchestratoru.
     """
-    RichPrinter.table(title, headers, rows)
-    header_str = " | ".join(map(str, headers))
-    rows_str = "\n".join([" | ".join(map(str, row)) for row in rows])
-    return f"Zobrazena tabulka '{title}':\n{header_str}\n{'-' * len(header_str)}\n{rows_str}"
+    content = {"title": title, "headers": headers, "rows": rows}
+    return json.dumps({"display": "table", "content": content})
 
 # --- MCP Server Boilerplate ---
 

--- a/tests/test_tui_tools.py
+++ b/tests/test_tui_tools.py
@@ -1,82 +1,54 @@
 import pytest
 import sys
 import os
-from unittest.mock import MagicMock
+import json
 
 # Přidání cesty k projektu pro importy
 project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
 sys.path.insert(0, project_root)
 
-# Importujeme nástroje a třídu, kterou budeme mockovat
+# Importujeme pouze testované nástroje
 from mcp_servers import tui_tools_server as tui_tools
-from core.rich_printer import RichPrinter
 
-@pytest.fixture
-def mock_rich_printer(monkeypatch):
-    """
-    Fixtura, která pomocí monkeypatch nahradí všechny relevantní metody
-    v RichPrinteru sledovatelnými MagicMock objekty.
-    """
-    mock_inform = MagicMock()
-    mock_warning = MagicMock()
-    mock_error = MagicMock()
-    mock_ask = MagicMock()
-    mock_code = MagicMock()
-    mock_table = MagicMock()
+# Mockování RichPrinteru již není potřeba, protože nástroje ho přímo nevolají.
 
-    monkeypatch.setattr(RichPrinter, 'inform', mock_inform)
-    monkeypatch.setattr(RichPrinter, 'warning', mock_warning)
-    monkeypatch.setattr(RichPrinter, 'error', mock_error)
-    monkeypatch.setattr(RichPrinter, 'ask', mock_ask)
-    monkeypatch.setattr(RichPrinter, 'code', mock_code)
-    monkeypatch.setattr(RichPrinter, 'table', mock_table)
-
-    return {
-        "inform": mock_inform,
-        "warning": mock_warning,
-        "error": mock_error,
-        "ask": mock_ask,
-        "code": mock_code,
-        "table": mock_table,
-    }
-
-def test_inform_user_calls_rich_printer(mock_rich_printer):
+def test_inform_user_returns_correct_json():
     message = "This is an info message."
     result = tui_tools.inform_user(message)
-    assert result == message
-    mock_rich_printer["inform"].assert_called_once_with(message)
+    data = json.loads(result)
+    assert data == {"display": "inform", "content": message}
 
-def test_warn_user_calls_rich_printer(mock_rich_printer):
+def test_warn_user_returns_correct_json():
     message = "This is a warning."
     result = tui_tools.warn_user(message)
-    assert result == message
-    mock_rich_printer["warning"].assert_called_once_with(message)
+    data = json.loads(result)
+    assert data == {"display": "warning", "content": message}
 
-def test_error_user_calls_rich_printer(mock_rich_printer):
+def test_error_user_returns_correct_json():
     message = "This is an error."
     result = tui_tools.error_user(message)
-    assert result == message
-    mock_rich_printer["error"].assert_called_once_with(message)
+    data = json.loads(result)
+    assert data == {"display": "error", "content": message}
 
-def test_ask_user_calls_rich_printer(mock_rich_printer):
+def test_ask_user_returns_correct_json():
     question = "What is your name?"
     result = tui_tools.ask_user(question)
-    assert question in result
-    mock_rich_printer["ask"].assert_called_once_with(question)
+    data = json.loads(result)
+    assert data == {"display": "ask", "content": question}
 
-def test_display_code_calls_rich_printer(mock_rich_printer):
+def test_display_code_returns_correct_json():
     code = "print('Hello, World!')"
     language = "python"
     result = tui_tools.display_code(code, language)
-    assert code in result
-    assert language in result
-    mock_rich_printer["code"].assert_called_once_with(code, language)
+    data = json.loads(result)
+    expected_content = {"code": code, "language": language}
+    assert data == {"display": "code", "content": expected_content}
 
-def test_display_table_calls_rich_printer(mock_rich_printer):
+def test_display_table_returns_correct_json():
     title = "My Table"
     headers = ["ID", "Name"]
     rows = [["1", "Alice"], ["2", "Bob"]]
     result = tui_tools.display_table(title, headers, rows)
-    assert title in result
-    assert "Alice" in result
-    mock_rich_printer["table"].assert_called_once_with(title, headers, rows)
+    data = json.loads(result)
+    expected_content = {"title": title, "headers": headers, "rows": rows}
+    assert data == {"display": "table", "content": expected_content}


### PR DESCRIPTION
…ion.

- Modified all TUI tools in `mcp_servers/tui_tools_server.py` to return a structured JSON string with `display` and `content` keys instead of calling `RichPrinter` directly.
- Updated `core/orchestrator.py` to intercept these JSON messages, parse them, and call the appropriate `RichPrinter` method to render the output in the TUI.
- Overwrote the tool result with a confirmation message after display to keep the agent's history clean.
- Updated the corresponding tests in `tests/test_tui_tools.py` to validate the new JSON output, ensuring the refactoring is fully tested.