### PR TITLE
Refactor(tools): Unify file system pathing to project root

### DIFF
--- a/mcp_servers/file_system_server.py
+++ b/mcp_servers/file_system_server.py
@@ -44,7 +44,6 @@ async def main():
         "create_file": file_system.create_file,
         "delete_file": file_system.delete_file,
         "rename_file": file_system.rename_file,
-        "create_new_tool": file_system.create_new_tool,
         "overwrite_file_with_block": file_system.overwrite_file_with_block,
         "create_file_with_block": file_system.create_file_with_block,
         "replace_with_git_merge_diff": file_system.replace_with_git_merge_diff,


### PR DESCRIPTION
- Removes the dual logic of a separate `SANDBOX_DIR` and the `PROJECT_ROOT/` prefix from all file system tools in `tools/file_system.py`.
- All paths are now treated as relative to the project root by default, which simplifies the tool APIs and their usage.
- The internal `_resolve_path` function has been hardened with more robust security checks to prevent path traversal attacks.
- Updates all docstrings to reflect the new, simpler behavior.
- Refactors the corresponding test suite in `tests/test_file_system_tools.py` to align with the new pathing logic, ensuring all changes are fully tested and validated.
- Fixes a startup error in `mcp_servers/file_system_server.py` by removing a reference to the deleted `create_new_tool` function.